### PR TITLE
Add basic MERN auth and charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# MERN Project
+# Personal Finance Management Application
+
+This repository contains a minimal MERN (MongoDB, Express, React, Node) style application for tracking personal finances. It now persists data to MongoDB and includes authentication. It provides:
+
+- **Income/expense records** with category support
+- **Monthly budget** setup and tracking
+- **Simple UI** with basic chart support
+- **Financial goals** and progress tracking
+
+## Structure
+
+- `server/` – Express API serving transaction, budget and goal endpoints with JWT-based user authentication
+- `client/` – Static React front-end using CDN scripts and Chart.js for simple visualization
+
+## Setup
+
+1. Install dependencies in both `server` and `client` directories:
+   ```bash
+   cd server && npm install
+   cd ../client && npm install
+   ```
+   (Network access is required for this step.)
+
+2. Start the API server (MongoDB must be running locally or specify `MONGO_URI`):
+   ```bash
+   cd server
+   export MONGO_URI="your-mongo-uri"
+   export JWT_SECRET="your-secret"
+   npm start
+   ```
+   The server listens on port `5000`.
+
+3. In a separate terminal start the client:
+   ```bash
+   cd client
+   npm start
+   ```
+   Then open `http://localhost:3000` in your browser.
+
+This project remains intentionally lightweight. For a real deployment you would enable HTTPS and configure environment variables for the database URI and JWT secret.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Finance Tracker</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    .container { max-width: 800px; margin: auto; }
+  </style>
+</head>
+<body>
+  <div id="app" class="container"></div>
+  <script type="text/babel">
+    const apiUrl = 'http://localhost:5000/api';
+    function App() {
+      const [token, setToken] = React.useState(localStorage.getItem('token'));
+      const [transactions, setTransactions] = React.useState([]);
+      const [description, setDescription] = React.useState('');
+      const [amount, setAmount] = React.useState(0);
+      const [category, setCategory] = React.useState('General');
+
+      React.useEffect(() => {
+        if (token) {
+          fetch(`${apiUrl}/transactions`, { headers: { Authorization: `Bearer ${token}` } })
+            .then(r => r.json()).then(setTransactions);
+        }
+      }, [token]);
+
+      React.useEffect(() => {
+        if (!transactions.length) return;
+        const ctx = document.getElementById('chart').getContext('2d');
+        new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: transactions.map(t => new Date(t.createdAt).toLocaleDateString()),
+            datasets: [{ label: 'Amount', data: transactions.map(t => t.amount), borderColor: 'blue' }]
+          }
+        });
+      }, [transactions]);
+
+      const login = async (username, password) => {
+        const res = await fetch(`${apiUrl}/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        if (res.ok) {
+          const { token } = await res.json();
+          localStorage.setItem('token', token);
+          setToken(token);
+        }
+      };
+
+      const register = async (username, password) => {
+        await fetch(`${apiUrl}/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username, password })
+        });
+        login(username, password);
+      };
+
+      const addTransaction = () => {
+        fetch(`${apiUrl}/transactions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ description, amount: parseFloat(amount), category })
+        })
+        .then(r => r.json())
+        .then(t => setTransactions([...transactions, t]));
+      };
+
+      return (
+        <div>
+          <h1>Finance Tracker</h1>
+          {!token && (
+            <AuthForm onLogin={login} onRegister={register} />
+          )}
+          {token && (
+            <>
+          <div>
+            <input placeholder="Description" value={description} onChange={e => setDescription(e.target.value)} />
+            <input type="number" placeholder="Amount" value={amount} onChange={e => setAmount(e.target.value)} />
+            <input placeholder="Category" value={category} onChange={e => setCategory(e.target.value)} />
+            <button onClick={addTransaction}>Add</button>
+          </div>
+          <h2>Transactions</h2>
+          <ul>
+            {transactions.map(t => <li key={t._id}>{t.description}: {t.amount} ({t.category})</li>)}
+          </ul>
+          <canvas id="chart" height="100"></canvas>
+          </>
+          )}
+        </div>
+      );
+    }
+
+    function AuthForm({ onLogin, onRegister }) {
+      const [username, setUsername] = React.useState('');
+      const [password, setPassword] = React.useState('');
+      return (
+        <div>
+          <input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+          <input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+          <button onClick={() => onLogin(username, password)}>Login</button>
+          <button onClick={() => onRegister(username, password)}>Register</button>
+        </div>
+      );
+    }
+    ReactDOM.render(<App />, document.getElementById('app'));
+  </script>
+</body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/client/server.js
+++ b/client/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.CLIENT_PORT || 3000;
+
+app.use(express.static(__dirname));
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(PORT, () => console.log(`Client running on port ${PORT}`));

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,129 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+const mongoose = require('mongoose');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+const MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/finance';
+const JWT_SECRET = process.env.JWT_SECRET || 'secret-key';
+
+mongoose.connect(MONGO_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
+
+const UserSchema = new mongoose.Schema({
+  username: { type: String, unique: true },
+  password: String
+});
+
+const TransactionSchema = new mongoose.Schema({
+  description: String,
+  amount: Number,
+  category: String,
+  createdAt: { type: Date, default: Date.now },
+  userId: mongoose.Schema.Types.ObjectId
+});
+
+const BudgetSchema = new mongoose.Schema({
+  month: String,
+  amount: Number,
+  userId: mongoose.Schema.Types.ObjectId
+});
+
+const GoalSchema = new mongoose.Schema({
+  name: String,
+  target: Number,
+  progress: { type: Number, default: 0 },
+  userId: mongoose.Schema.Types.ObjectId
+});
+
+const User = mongoose.model('User', UserSchema);
+const Transaction = mongoose.model('Transaction', TransactionSchema);
+const Budget = mongoose.model('Budget', BudgetSchema);
+const Goal = mongoose.model('Goal', GoalSchema);
+
+app.use(cors());
+app.use(bodyParser.json());
+
+// ----- Authentication -----
+function auth(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided' });
+  try {
+    const user = jwt.verify(token, JWT_SECRET);
+    req.userId = user.id;
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  const hashed = await bcrypt.hash(password, 10);
+  try {
+    const user = await User.create({ username, password: hashed });
+    res.status(201).json({ id: user._id, username: user.username });
+  } catch {
+    res.status(400).json({ message: 'User already exists' });
+  }
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = await User.findOne({ username });
+  if (!user) return res.status(401).json({ message: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) return res.status(401).json({ message: 'Invalid credentials' });
+  const token = jwt.sign({ id: user._id }, JWT_SECRET);
+  res.json({ token });
+});
+
+// ----- Transactions -----
+app.get('/api/transactions', auth, async (req, res) => {
+  const items = await Transaction.find({ userId: req.userId });
+  res.json(items);
+});
+
+app.post('/api/transactions', auth, async (req, res) => {
+  const transaction = await Transaction.create({ ...req.body, userId: req.userId });
+  res.status(201).json(transaction);
+});
+
+app.put('/api/transactions/:id', auth, async (req, res) => {
+  const t = await Transaction.findOneAndUpdate({ _id: req.params.id, userId: req.userId }, req.body, { new: true });
+  res.json(t);
+});
+
+app.delete('/api/transactions/:id', auth, async (req, res) => {
+  await Transaction.deleteOne({ _id: req.params.id, userId: req.userId });
+  res.status(204).end();
+});
+
+// ----- Budgets -----
+app.get('/api/budgets', auth, async (req, res) => {
+  const items = await Budget.find({ userId: req.userId });
+  res.json(items);
+});
+
+app.post('/api/budgets', auth, async (req, res) => {
+  const budget = await Budget.create({ ...req.body, userId: req.userId });
+  res.status(201).json(budget);
+});
+
+// ----- Goals -----
+app.get('/api/goals', auth, async (req, res) => {
+  const items = await Goal.find({ userId: req.userId });
+  res.json(items);
+});
+
+app.post('/api/goals', auth, async (req, res) => {
+  const goal = await Goal.create({ ...req.body, userId: req.userId });
+  res.status(201).json(goal);
+});
+
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "cors": "^2.8.5",
+    "mongoose": "^7.6.1",
+    "bcrypt": "^5.1.1",
+    "jsonwebtoken": "^9.0.2"
+  }
+}


### PR DESCRIPTION
## Summary
- connect Express API to MongoDB via Mongoose and add JWT auth
- implement CRUD endpoints for transactions and simple routes for budgets and goals
- update server dependencies
- create login/register flow and Chart.js visualization in the React client
- document new setup instructions for database and JWT secret

## Testing
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm test` in `client` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842358484848320bf4be0c30a578eda